### PR TITLE
Agregar la opcion de ingresar el baseURI de manera dinamica 

### DIFF
--- a/contracts/base/ERC721Token.sol
+++ b/contracts/base/ERC721Token.sol
@@ -16,11 +16,13 @@ contract ERC721Token is
 {
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    string public baseURI;
 
-    constructor(string memory name, string memory symbol) ERC721(name, symbol) {
+    constructor(string memory name, string memory symbol, string memory newBaseURI) ERC721(name, symbol) {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(PAUSER_ROLE, msg.sender);
         _grantRole(MINTER_ROLE, msg.sender);
+        baseURI = newBaseURI;
     }
 
     function pause() public onlyRole(PAUSER_ROLE) {
@@ -29,6 +31,10 @@ contract ERC721Token is
 
     function unpause() public onlyRole(PAUSER_ROLE) {
         _unpause();
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return baseURI;
     }
 
     function safeMint(

--- a/contracts/factory/FactoryERC721Token.sol
+++ b/contracts/factory/FactoryERC721Token.sol
@@ -11,9 +11,10 @@ contract FactoryERC721 {
 
     function createNewContract(
         string memory name,
-        string memory symbol
+        string memory symbol,
+        string memory baseURI
     ) public {
-        ERC721Token newERC721 = new ERC721Token(name, symbol);
+        ERC721Token newERC721 = new ERC721Token(name, symbol,baseURI);
         ERC721Array.push(newERC721);
         amountOfContracts++;
         emit NewContract(address(newERC721));


### PR DESCRIPTION
Noté que el facotry no tenía una opción dinámica de agregar el baseURI de cada ERC721 contract, el cual ahora se puede agregar como parámetro además de Name y Symbol